### PR TITLE
Remove scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,3 @@ _skbuild
 # sphinx
 docs/html/
 docs/output/
-
-# setuptools-scm
-python/kedm/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [build-system]
-requires = ["scikit-build-core", "setuptools-scm"]
+requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "kedm"
-dynamic = ["version"]
+version = "0.9.1"
 authors = [
     { name="Keichi Takahashi", email="hello@keichi.dev" }
 ]
 description = "A high-performance implementation of the Empirical Dynamic Modeling (EDM) framework"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 classifiers = [
     "Programming Language :: C++",
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 dependencies = [
-    "numpy>=1.7.0"
+    "numpy>=2.0.0"
 ]
 
 [project.urls]
@@ -40,14 +40,9 @@ test = [
 wheel.install-dir = "kedm"
 wheel.packages = ["python/kedm"]
 cmake.version = ">=3.16"
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["python/kedm/_version.py"]
 
 [tool.scikit-build.cmake.define]
 KEDM_ENABLE_PYTHON = true
 KEDM_ENABLE_TESTS = false
 KEDM_ENABLE_EXECUTABLES = false
 KEDM_ENABLE_CPU = true
-
-[tool.setuptools_scm]
-version_file = "python/kedm/_version.py"

--- a/python/kedm/__init__.py
+++ b/python/kedm/__init__.py
@@ -18,4 +18,4 @@ Python bindings for kEDM
 """
 
 from ._kedm import *
-from ._version import version as __version__
+from ._version import __version__

--- a/python/kedm/_version.py
+++ b/python/kedm/_version.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("kedm")


### PR DESCRIPTION
When building CUDA wheels on GHA, we edit `pyproject.toml` to postfix the package name with `-cuda11x` or `-cuda12x`. This causes setuptools-scm to generate a version string like `0.7.0+10.gf72d7f0.dirty`, making the resulting wheel not uploadable to PyPI. Since editing `pyproject.toml` seems to be the only way to override the package name, we have to remove setuptools-scm for now.