### PR TITLE
Lower requird numpy version to 1.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 dependencies = [
-    "numpy>=2.0.0"
+    "numpy>=1.24.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
We ned to degrade the required numpy version because numpy 2.x does not support Python 3.8.