### PR TITLE
Refactor sort functions and fix integer overflow

### DIFF
--- a/src/ccm.cpp
+++ b/src/ccm.cpp
@@ -110,9 +110,9 @@ void full_sort_stl(TmpDistances distances, TmpIndices indices, int n_lib,
     auto indices_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), indices);
 
     Kokkos::parallel_for(
-        "EDM::ccm::full_sort_stl",
+        "EDM::ccm::sort",
         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n_pred),
-        [=](int i) {
+        [=](size_t i) {
             float *dist_row = &distances_h(i, 0);
             int *ind_row = &indices_h(i, 0);
 

--- a/src/ccm.cpp
+++ b/src/ccm.cpp
@@ -328,9 +328,8 @@ void partial_sort_stl(TmpDistances distances, TmpIndices indices, int k,
     auto indices_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), indices);
 
     Kokkos::parallel_for(
-        "EDM::ccm::partial_sort_stl",
-        Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n_pred),
-        [=](int i) {
+        "EDM::ccm::partial_sort_stl", n_pred,
+        [=](size_t i) {
             float *dist_row = &distances_h(i, 0);
             int *ind_row = &indices_h(i, 0);
 

--- a/src/ccm.cpp
+++ b/src/ccm.cpp
@@ -102,7 +102,7 @@ void full_sort_with_scratch(TmpDistances distances, TmpIndices indices,
         });
 }
 
-void full_sort_cpu(TmpDistances distances, TmpIndices indices, int n_lib,
+void full_sort_stl(TmpDistances distances, TmpIndices indices, int n_lib,
                    int n_pred, int n_partial, int Tp)
 {
     auto distances_h =
@@ -110,7 +110,7 @@ void full_sort_cpu(TmpDistances distances, TmpIndices indices, int n_lib,
     auto indices_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), indices);
 
     Kokkos::parallel_for(
-        "EDM::ccm::full_sort_cpu",
+        "EDM::ccm::full_sort_stl",
         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n_pred),
         [=](int i) {
             float *dist_row = &distances_h(i, 0);
@@ -320,7 +320,7 @@ void partial_sort(TmpDistances distances, TmpIndices indices, int k, int n_lib,
         });
 }
 
-void partial_sort_cpu(TmpDistances distances, TmpIndices indices, int k,
+void partial_sort_stl(TmpDistances distances, TmpIndices indices, int k,
                       int n_lib, int n_pred, int n_partial, int Tp)
 {
     auto distances_h =
@@ -328,7 +328,7 @@ void partial_sort_cpu(TmpDistances distances, TmpIndices indices, int k,
     auto indices_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), indices);
 
     Kokkos::parallel_for(
-        "EDM::ccm::partial_sort_cpu",
+        "EDM::ccm::partial_sort_stl",
         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n_pred),
         [=](int i) {
             float *dist_row = &distances_h(i, 0);

--- a/src/ccm.cpp
+++ b/src/ccm.cpp
@@ -48,6 +48,7 @@ void full_sort_kokkos(TmpDistances distances, TmpIndices indices, int n_lib,
 void full_sort(TmpDistances distances, TmpIndices indices, int n_lib,
                int n_pred, int n_partial, int Tp)
 {
+#ifdef KOKKOS_ENABLE_CUDA
     bool use_scratch =
         ScratchDistances1D::shmem_size(distances.extent(1)) +
             ScratchIndices1D::shmem_size(indices.extent(1)) <
@@ -57,12 +58,11 @@ void full_sort(TmpDistances distances, TmpIndices indices, int n_lib,
         full_sort_with_scratch(distances, indices, n_lib, n_pred, n_partial,
                                Tp);
     } else {
-#ifdef KOKKOS_ENABLE_CUDA
         full_sort_cub(distances, indices, n_lib, n_pred, n_partial, Tp);
-#else
-        full_sort_kokkos(distances, indices, n_lib, n_pred, n_partial, Tp);
-#endif
     }
+#else
+    full_sort_stl(distances, indices, n_lib, n_pred, n_partial, Tp);
+#endif
 }
 
 void full_sort_with_scratch(TmpDistances distances, TmpIndices indices,

--- a/src/ccm.hpp
+++ b/src/ccm.hpp
@@ -26,6 +26,9 @@ void full_sort_cub(TmpDistances distances, TmpIndices indices, int n_lib,
 void partial_sort(TmpDistances distances, TmpIndices indices, int k, int n_lib,
                   int n_pred, int n_partial, int Tp);
 
+void partial_sort_kokkos(TmpDistances distances, TmpIndices indices, int k,
+                         int n_lib, int n_pred, int n_partial, int Tp);
+
 void partial_sort_stl(TmpDistances distances, TmpIndices indices, int k,
                       int n_lib, int n_pred, int n_partial, int Tp);
 

--- a/src/ccm.hpp
+++ b/src/ccm.hpp
@@ -17,7 +17,7 @@ void full_sort_kokkos(TmpDistances distances, TmpIndices indices, int n_lib,
 void full_sort_with_scratch(TmpDistances distances, TmpIndices indices,
                             int n_lib, int n_pred, int n_partial, int Tp);
 
-void full_sort_cpu(TmpDistances distances, TmpIndices indices, int n_lib,
+void full_sort_stl(TmpDistances distances, TmpIndices indices, int n_lib,
                    int n_pred, int n_partial, int Tp);
 
 void full_sort_cub(TmpDistances distances, TmpIndices indices, int n_lib,
@@ -26,7 +26,7 @@ void full_sort_cub(TmpDistances distances, TmpIndices indices, int n_lib,
 void partial_sort(TmpDistances distances, TmpIndices indices, int k, int n_lib,
                   int n_pred, int n_partial, int Tp);
 
-void partial_sort_cpu(TmpDistances distances, TmpIndices indices, int k,
+void partial_sort_stl(TmpDistances distances, TmpIndices indices, int k,
                       int n_lib, int n_pred, int n_partial, int Tp);
 
 std::vector<float> ccm(TimeSeries library, TimeSeries target,

--- a/src/ccm.hpp
+++ b/src/ccm.hpp
@@ -20,8 +20,8 @@ void full_sort_with_scratch(TmpDistances distances, TmpIndices indices,
 void full_sort_cpu(TmpDistances distances, TmpIndices indices, int n_lib,
                    int n_pred, int n_partial, int Tp);
 
-void full_sort_radix(TmpDistances distances, TmpIndices indices, int n_lib,
-                     int n_pred, int n_partial, int Tp);
+void full_sort_cub(TmpDistances distances, TmpIndices indices, int n_lib,
+                   int n_pred, int n_partial, int Tp);
 
 void partial_sort(TmpDistances distances, TmpIndices indices, int k, int n_lib,
                   int n_pred, int n_partial, int Tp);

--- a/src/partial_sort_bench.cpp
+++ b/src/partial_sort_bench.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     {
         LIKWID_MARKER_THREADINIT;
 
-        LIKWID_MARKER_REGISTER("partial_sort");
+        LIKWID_MARKER_REGISTER("partial_sort_kokkos");
         LIKWID_MARKER_REGISTER("partial_sort_stl");
         LIKWID_MARKER_REGISTER("full_sort");
         LIKWID_MARKER_REGISTER("full_sort_stl");
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
             } else if (stl) {
                 LIKWID_MARKER_START("partial_sort_stl");
             } else {
-                LIKWID_MARKER_START("partial_sort");
+                LIKWID_MARKER_START("partial_sort_kokkos");
             }
         }
 
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
         } else if (stl) {
             edm::partial_sort_stl(distances, indices, k, N, N, 0, 0);
         } else {
-            edm::partial_sort(distances, indices, k, N, N, 0, 0);
+            edm::partial_sort_kokkos(distances, indices, k, N, N, 0, 0);
         }
 
         Kokkos::fence();
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
             } else if (stl) {
                 LIKWID_MARKER_STOP("partial_sort_stl");
             } else {
-                LIKWID_MARKER_STOP("partial_sort");
+                LIKWID_MARKER_STOP("partial_sort_kokkos");
             }
         }
 
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
         std::cout << "partial_sort_stl " << timer_sort.elapsed() / iterations
                   << std::endl;
     } else {
-        std::cout << "partial_sort " << timer_sort.elapsed() / iterations
+        std::cout << "partial_sort_kokkos " << timer_sort.elapsed() / iterations
                   << std::endl;
     }
 

--- a/src/partial_sort_bench.cpp
+++ b/src/partial_sort_bench.cpp
@@ -101,13 +101,8 @@ int main(int argc, char *argv[])
     {
         LIKWID_MARKER_THREADINIT;
 
-        LIKWID_MARKER_REGISTER("partial_sort_kokkos");
-        LIKWID_MARKER_REGISTER("partial_sort_stl");
+        LIKWID_MARKER_REGISTER("partial_sort");
         LIKWID_MARKER_REGISTER("full_sort");
-        LIKWID_MARKER_REGISTER("full_sort_stl");
-        LIKWID_MARKER_REGISTER("full_sort_cub");
-        LIKWID_MARKER_REGISTER("full_sort_scratch");
-        LIKWID_MARKER_REGISTER("full_sort_kokkos");
     }
 
     for (auto i = 0; i < iterations; i++) {
@@ -121,20 +116,10 @@ int main(int argc, char *argv[])
 #pragma omp parallel
 #endif
         {
-            if (full && stl) {
-                LIKWID_MARKER_START("full_sort_stl");
-            } else if (full && cub) {
-                LIKWID_MARKER_START("full_sort_cub");
-            } else if (full && scratch) {
-                LIKWID_MARKER_START("full_sort_scratch");
-            } else if (full && kokkos_sort) {
-                LIKWID_MARKER_START("full_sort_kokkos");
-            } else if (full) {
+            if (full) {
                 LIKWID_MARKER_START("full_sort");
-            } else if (stl) {
-                LIKWID_MARKER_START("partial_sort_stl");
             } else {
-                LIKWID_MARKER_START("partial_sort_kokkos");
+                LIKWID_MARKER_START("partial_sort");
             }
         }
 
@@ -160,20 +145,10 @@ int main(int argc, char *argv[])
 #pragma omp parallel
 #endif
         {
-            if (full && stl) {
-                LIKWID_MARKER_STOP("full_sort_stl");
-            } else if (full && cub) {
-                LIKWID_MARKER_STOP("full_sort_cub");
-            } else if (full && scratch) {
-                LIKWID_MARKER_STOP("full_sort_scratch");
-            } else if (full && kokkos_sort) {
-                LIKWID_MARKER_STOP("full_sort_kokkos");
-            } else if (full) {
+            if (full) {
                 LIKWID_MARKER_STOP("full_sort");
-            } else if (stl) {
-                LIKWID_MARKER_STOP("partial_sort_stl");
             } else {
-                LIKWID_MARKER_STOP("partial_sort_kokkos");
+                LIKWID_MARKER_STOP("partial_sort");
             }
         }
 

--- a/src/partial_sort_bench.cpp
+++ b/src/partial_sort_bench.cpp
@@ -102,10 +102,10 @@ int main(int argc, char *argv[])
         LIKWID_MARKER_THREADINIT;
 
         LIKWID_MARKER_REGISTER("partial_sort");
-        LIKWID_MARKER_REGISTER("partial_sort_cpu");
+        LIKWID_MARKER_REGISTER("partial_sort_stl");
         LIKWID_MARKER_REGISTER("full_sort");
-        LIKWID_MARKER_REGISTER("full_sort_cpu");
-        LIKWID_MARKER_REGISTER("full_sort_radix");
+        LIKWID_MARKER_REGISTER("full_sort_stl");
+        LIKWID_MARKER_REGISTER("full_sort_cub");
         LIKWID_MARKER_REGISTER("full_sort_scratch");
         LIKWID_MARKER_REGISTER("full_sort_kokkos");
     }
@@ -122,9 +122,9 @@ int main(int argc, char *argv[])
 #endif
         {
             if (full && stl) {
-                LIKWID_MARKER_START("full_sort_cpu");
+                LIKWID_MARKER_START("full_sort_stl");
             } else if (full && cub) {
-                LIKWID_MARKER_START("full_sort_radix");
+                LIKWID_MARKER_START("full_sort_cub");
             } else if (full && scratch) {
                 LIKWID_MARKER_START("full_sort_scratch");
             } else if (full && kokkos_sort) {
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
             } else if (full) {
                 LIKWID_MARKER_START("full_sort");
             } else if (stl) {
-                LIKWID_MARKER_START("partial_sort_cpu");
+                LIKWID_MARKER_START("partial_sort_stl");
             } else {
                 LIKWID_MARKER_START("partial_sort");
             }
@@ -161,9 +161,9 @@ int main(int argc, char *argv[])
 #endif
         {
             if (full && stl) {
-                LIKWID_MARKER_STOP("full_sort_cpu");
+                LIKWID_MARKER_STOP("full_sort_stl");
             } else if (full && cub) {
-                LIKWID_MARKER_STOP("full_sort_radix");
+                LIKWID_MARKER_STOP("full_sort_cub");
             } else if (full && scratch) {
                 LIKWID_MARKER_STOP("full_sort_scratch");
             } else if (full && kokkos_sort) {
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
             } else if (full) {
                 LIKWID_MARKER_STOP("full_sort");
             } else if (stl) {
-                LIKWID_MARKER_STOP("partial_sort_cpu");
+                LIKWID_MARKER_STOP("partial_sort_stl");
             } else {
                 LIKWID_MARKER_STOP("partial_sort");
             }
@@ -185,10 +185,10 @@ int main(int argc, char *argv[])
     std::cout << "elapsed: " << timer.seconds() << " [s]" << std::endl;
 
     if (full && stl) {
-        std::cout << "full_sort_cpu " << timer_sort.elapsed() / iterations
+        std::cout << "full_sort_stl " << timer_sort.elapsed() / iterations
                   << std::endl;
     } else if (full && cub) {
-        std::cout << "full_sort_radix " << timer_sort.elapsed() / iterations
+        std::cout << "full_sort_cub " << timer_sort.elapsed() / iterations
                   << std::endl;
     } else if (full && scratch) {
         std::cout << "full_sort_scratch " << timer_sort.elapsed() / iterations
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
         std::cout << "full_sort " << timer_sort.elapsed() / iterations
                   << std::endl;
     } else if (stl) {
-        std::cout << "partial_sort_cpu " << timer_sort.elapsed() / iterations
+        std::cout << "partial_sort_stl " << timer_sort.elapsed() / iterations
                   << std::endl;
     } else {
         std::cout << "partial_sort " << timer_sort.elapsed() / iterations

--- a/test/ccm_test.cpp
+++ b/test/ccm_test.cpp
@@ -132,7 +132,7 @@ TEST_CASE("Partially sort kNN LUT (CPU version)")
     auto valid_dist = Kokkos::create_mirror(HostSpace(), dist);
     Kokkos::deep_copy(valid_dist, dist);
 
-    edm::partial_sort_cpu(dist, ind, K, L, N, n_partial, Tp);
+    edm::partial_sort_stl(dist, ind, K, L, N, n_partial, Tp);
 
     auto distances = Kokkos::create_mirror_view_and_copy(HostSpace(), dist);
     auto indices = Kokkos::create_mirror_view_and_copy(HostSpace(), ind);
@@ -212,7 +212,7 @@ TEST_CASE("Full sort kNN LUT (CPU version)")
     auto valid_dist = Kokkos::create_mirror(HostSpace(), dist);
     Kokkos::deep_copy(valid_dist, dist);
 
-    edm::full_sort_cpu(dist, ind, L, N, n_partial, Tp);
+    edm::full_sort_stl(dist, ind, L, N, n_partial, Tp);
 
     auto distances = Kokkos::create_mirror_view_and_copy(HostSpace(), dist);
     auto indices = Kokkos::create_mirror_view_and_copy(HostSpace(), ind);


### PR DESCRIPTION
## Summary
- Rename `full_sort_radix` to `full_sort_cub` for clarity
- Rename CPU sort functions to use `_stl` suffix (`full_sort_cpu` → `full_sort_stl`, `partial_sort_cpu` → `partial_sort_stl`)
- Add `partial_sort` wrapper function that dispatches to `partial_sort_kokkos` on CUDA or `partial_sort_stl` on CPU, consistent with `full_sort` pattern
- Use STL sort unconditionally on CPU for `full_sort`
- Fix integer overflow in loop indices by changing `int` to `size_t`
- Simplify LIKWID marker names in partial_sort_bench
- Switch from CUB `DeviceSegmentedRadixSort` to `DeviceSegmentedSort` and fix issue where distance matrix with more than INT_MAX elements would fail

## Test plan
- [x] All 23 tests pass
- [x] Build succeeds on CPU (OpenMP backend)