### PR TITLE
Spack package for kEDM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,10 @@ else()
   # Kokkos: controlled by external build (Spack variants), not by cache vars above.
   find_package(Kokkos CONFIG REQUIRED)
 # ---- argh (external-first, fallback) ----
-  find_path(ARHG_INCLUDE_DIR argh.h)
-  if(ARHG_INCLUDE_DIR)
+  find_path(ARGH_INCLUDE_DIR argh.h)
+  if(ARGH_INCLUDE_DIR)
     add_library(argh INTERFACE)
-    target_include_directories(argh INTERFACE ${ARHG_INCLUDE_DIR})
+    target_include_directories(argh INTERFACE ${ARGH_INCLUDE_DIR})
   else()
     include(FetchContent)
     FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,6 @@ if(KEDM_ENABLE_SIMD_PRIMITIVES)
 endif()
 
 # Python bindings
-option(KEDM_ENABLE_PYTHON "Build Python bindings")
 if(KEDM_ENABLE_PYTHON)
   if(NOT KEDM_USE_EXTERNAL_DEPS)
     include(FetchContent)
@@ -292,7 +291,6 @@ if(KEDM_ENABLE_PYTHON)
 endif()
 
 # Unit tests
-option(KEDM_ENABLE_TESTS "Build unit tests" ON)
 if(KEDM_ENABLE_TESTS)
   enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,33 @@ set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 project(kokkos-edm CXX)
 
-include(FetchContent)
+# Options
+option(KEDM_USE_EXTERNAL_DEPS "Prefer find_package() for dependencies (e.g. Spack), otherwise FetchContent" OFF)
 
-# Compiler flags
+# Kokkos
+option(KEDM_ENABLE_CPU "Enable CPU (OpenMP) backend" ON)
+option(KEDM_ENABLE_GPU "Enable GPU (CUDA) backend" OFF)
+
+# MPI
+option(KEDM_ENABLE_MPI "Enable MPI" OFF)
+
+# Executables
+option(KEDM_ENABLE_EXECUTABLES "Build executables" ON)
+
+# LIKWID
+option(KEDM_ENABLE_LIKWID "Enable LIKWID performance counters" OFF)
+
+# Kokkos features
+option(KEDM_ENABLE_SCRATCH_MEMORY "Use Kokkos scratch memory" ON)
+option(KEDM_ENABLE_SIMD_PRIMITIVES "Use Kokkos SIMD primitives" ON)
+
+# Python bindings
+option(KEDM_ENABLE_PYTHON "Build Python bindings" OFF)
+
+# Unit tests
+option(KEDM_ENABLE_TESTS "Build unit tests" ON)
+
+# Compiler flags / global CMake
 add_compile_options(-Wall -Wextra)
 if(APPLE)
   # gcc needs this flag to compile Accelerate
@@ -32,40 +56,71 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(Kokkos_ENABLE_DEBUG_BOUNDS_CHECK ON CACHE BOOL "")
 endif()
 
-# LTO is unsporrted by CUDA
+# LTO is unsupported by CUDA
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Kokkos
-option(KEDM_ENABLE_CPU "Enable CPU (OpenMP) backend" ON)
-if(KEDM_ENABLE_CPU)
-  set(Kokkos_ENABLE_OPENMP ON CACHE BOOL "")
-  set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION ON CACHE BOOL "")
+# ----------------------------
+# Dependencies
+# ----------------------------
+if(NOT KEDM_USE_EXTERNAL_DEPS)
+  include(FetchContent)
+  # Configure Kokkos only for the FetchContent build.
+  if(KEDM_ENABLE_CPU)
+    set(Kokkos_ENABLE_OPENMP ON CACHE BOOL "")
+    set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION ON CACHE BOOL "")
+  endif()
+
+  if(KEDM_ENABLE_GPU)
+    set(Kokkos_ENABLE_CUDA ON CACHE BOOL "")
+    set(Kokkos_ENABLE_CUDA_LAMBDA ON CACHE BOOL "")
+  endif()
+
+  # Kokkos
+  FetchContent_Declare(
+    kokkos
+    GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+    GIT_TAG 5.0.0
+    EXCLUDE_FROM_ALL
+  )
+  FetchContent_MakeAvailable(kokkos)
+
+  # argh
+  FetchContent_Declare(
+    argh
+    GIT_REPOSITORY https://github.com/adishavit/argh.git
+    GIT_TAG v1.3.2
+  )
+  FetchContent_MakeAvailable(argh)
+
+
+
+else()
+  # External deps (Spack): prefer exported CMake packages/targets.
+
+  # Kokkos: controlled by external build (Spack variants), not by cache vars above.
+  find_package(Kokkos CONFIG REQUIRED)
+# ---- argh (external-first, fallback) ----
+  find_path(ARHG_INCLUDE_DIR argh.h)
+  if(ARHG_INCLUDE_DIR)
+    add_library(argh INTERFACE)
+    target_include_directories(argh INTERFACE ${ARHG_INCLUDE_DIR})
+  else()
+    include(FetchContent)
+    FetchContent_Declare(
+      argh
+      GIT_REPOSITORY https://github.com/adishavit/argh.git
+      GIT_TAG v1.3.2
+    )
+    FetchContent_MakeAvailable(argh)
+  endif()
 endif()
-option(KEDM_ENABLE_GPU "Enable GPU (CUDA) backend" OFF)
-if(KEDM_ENABLE_GPU)
-  set(Kokkos_ENABLE_CUDA ON CACHE BOOL "")
-  set(Kokkos_ENABLE_CUDA_LAMBDA ON CACHE BOOL "")
-endif()
 
-FetchContent_Declare(
-  kokkos
-  GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-  GIT_TAG        5.0.0
-  EXCLUDE_FROM_ALL
-)
-FetchContent_MakeAvailable(kokkos)
-
-# argh
-FetchContent_Declare(
-  argh
-  GIT_REPOSITORY https://github.com/adishavit/argh.git
-  GIT_TAG        v1.3.2
-)
-FetchContent_MakeAvailable(argh)
-
+# ----------------------------
 # Main library
-add_library(kedm
+# ----------------------------
+add_library(
+  kedm
   src/ccm.cpp
   src/edim.cpp
   src/io.cpp
@@ -73,28 +128,70 @@ add_library(kedm
   src/xmap.cpp
   src/knn.cpp
   src/smap.cpp
-  src/stats.cpp)
+  src/stats.cpp
+)
+
 target_link_libraries(kedm PRIVATE Kokkos::kokkos)
 
 # boost-math
-FetchContent_Declare(
-  boost-math
-  GIT_REPOSITORY https://github.com/boostorg/math.git
-  GIT_TAG        boost-1.89.0
-)
-FetchContent_MakeAvailable(boost-math)
+if(NOT KEDM_USE_EXTERNAL_DEPS)
+  # boost-math (provides Boost::math target)
+  FetchContent_Declare(
+    boost-math
+    GIT_REPOSITORY https://github.com/boostorg/math.git
+    GIT_TAG boost-1.89.0
+  )
+  FetchContent_MakeAvailable(boost-math)
+else()
+  find_package(Boost REQUIRED)
+  if(NOT TARGET Boost::math)
+    add_library(Boost::math INTERFACE IMPORTED)
+    if(Boost_INCLUDE_DIRS)
+      set_target_properties(Boost::math PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+      )
+    endif()
+    if(TARGET Boost::boost)
+      target_link_libraries(Boost::math INTERFACE Boost::boost)
+    endif()
+  endif()
+endif()
 target_link_libraries(kedm PRIVATE Boost::math)
 
-# pcg
-FetchContent_Declare(
-  pcg
-  GIT_REPOSITORY https://github.com/imneme/pcg-cpp.git
-  GIT_TAG        v0.98.1
-)
-FetchContent_MakeAvailable(pcg)
-target_include_directories(kedm PRIVATE ${pcg_SOURCE_DIR}/include)
+# PCG headers
+if(NOT KEDM_USE_EXTERNAL_DEPS)
+  # pcg
+  FetchContent_Declare(
+    pcg
+    GIT_REPOSITORY https://github.com/imneme/pcg-cpp.git
+    GIT_TAG v0.98.1
+  )
+  FetchContent_MakeAvailable(pcg)
+  target_include_directories(kedm PRIVATE ${pcg_SOURCE_DIR}/include)
+else()
+    # ---- pcg-cpp (external-first, fallback) ----
+  find_path(PCG_INCLUDE_DIR pcg_random.hpp PATH_SUFFIXES pcg)
+  if(NOT PCG_INCLUDE_DIR)
+    find_path(PCG_INCLUDE_DIR pcg_random.hpp)
+  endif()
 
-# LAPACK
+  if(PCG_INCLUDE_DIR)
+    # keep using include dirs (no target upstream)
+    set(KEDM_PCG_INCLUDE_DIR "${PCG_INCLUDE_DIR}")
+  else()
+    include(FetchContent)
+    FetchContent_Declare(
+      pcg
+      GIT_REPOSITORY https://github.com/imneme/pcg-cpp.git
+      GIT_TAG v0.98.1
+    )
+    FetchContent_MakeAvailable(pcg)
+    set(KEDM_PCG_INCLUDE_DIR "${pcg_SOURCE_DIR}/include")
+  endif()
+  target_include_directories(kedm PRIVATE ${KEDM_PCG_INCLUDE_DIR})
+endif()
+
+# LAPACK / CUDA BLAS
 if (Kokkos_ENABLE_CUDA)
   find_package(CUDAToolkit REQUIRED)
   target_link_libraries(kedm PRIVATE CUDA::cublas)
@@ -104,26 +201,30 @@ else()
 endif()
 
 # MPI
-option(KEDM_ENABLE_MPI "Enable MPI")
 if(KEDM_ENABLE_MPI)
   find_package(MPI REQUIRED)
 endif()
 
 # Executables
-option(KEDM_ENABLE_EXECUTABLES "Build executables" ON)
 if(KEDM_ENABLE_EXECUTABLES)
-  # HighFive
-  set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "")
-  set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "")
-  set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "")
-  set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "")
 
-  FetchContent_Declare(
-    highfive
-    GIT_REPOSITORY https://github.com/highfive-devs/highfive.git
-    GIT_TAG        v3.2.0
-  )
-  FetchContent_MakeAvailable(highfive)
+  # HighFive / HDF5
+  if(NOT KEDM_USE_EXTERNAL_DEPS)
+    set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "")
+    set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "")
+    set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "")
+    set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "")
+
+    FetchContent_Declare(
+      highfive
+      GIT_REPOSITORY https://github.com/highfive-devs/highfive.git
+      GIT_TAG v3.2.0
+    )
+    FetchContent_MakeAvailable(highfive)
+  else()
+    # Prefer the exported HighFive config if available
+    find_package(HighFive CONFIG REQUIRED)
+  endif()
 
   target_link_libraries(kedm PRIVATE HighFive)
   target_compile_definitions(kedm PRIVATE -DHAVE_HDF5)
@@ -152,23 +253,20 @@ if(KEDM_ENABLE_EXECUTABLES)
   endif()
 endif()
 
-option(KEDM_ENABLE_LIKWID "Enable LIKWID performance counters")
+# LIKWID
 if(KEDM_ENABLE_LIKWID)
   find_package(likwid)
-
   target_link_libraries(knn-bench PRIVATE likwid::likwid)
   target_compile_definitions(knn-bench PRIVATE -DLIKWID_PERFMON)
-
   target_link_libraries(lookup-bench PRIVATE likwid::likwid)
   target_compile_definitions(lookup-bench PRIVATE -DLIKWID_PERFMON)
 endif()
 
-option(KEDM_ENABLE_SCRATCH_MEMORY "Use Kokkos scratch memory" ON)
+# Kokkos 
 if(KEDM_ENABLE_SCRATCH_MEMORY)
   target_compile_definitions(kedm PRIVATE -DUSE_SCRATCH_MEMORY)
 endif()
 
-option(KEDM_ENABLE_SIMD_PRIMITIVES "Use Kokkos SIMD primitives" ON)
 if(KEDM_ENABLE_SIMD_PRIMITIVES)
   target_compile_definitions(kedm PRIVATE -DUSE_SIMD_PRIMITIVES)
 endif()
@@ -176,13 +274,17 @@ endif()
 # Python bindings
 option(KEDM_ENABLE_PYTHON "Build Python bindings")
 if(KEDM_ENABLE_PYTHON)
-  # pybind11
-  FetchContent_Declare(
-    pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v3.0.1
-  )
-  FetchContent_MakeAvailable(pybind11)
+  if(NOT KEDM_USE_EXTERNAL_DEPS)
+    include(FetchContent)
+    FetchContent_Declare(
+      pybind11
+      GIT_REPOSITORY https://github.com/pybind/pybind11.git
+      GIT_TAG v3.0.1
+    )
+    FetchContent_MakeAvailable(pybind11)
+  else()
+    find_package(pybind11 CONFIG REQUIRED)
+  endif()
 
   pybind11_add_module(_kedm src/bindings.cpp)
   target_link_libraries(_kedm PRIVATE kedm Kokkos::kokkos)
@@ -194,16 +296,22 @@ option(KEDM_ENABLE_TESTS "Build unit tests" ON)
 if(KEDM_ENABLE_TESTS)
   enable_testing()
 
-  # doctest
-  FetchContent_Declare(
-    doctest
-    GIT_REPOSITORY https://github.com/doctest/doctest.git
-    GIT_TAG        v2.4.12
-  )
-  FetchContent_MakeAvailable(doctest)
-  include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+  if(NOT KEDM_USE_EXTERNAL_DEPS)
+    include(FetchContent)
+    FetchContent_Declare(
+      doctest
+      GIT_REPOSITORY https://github.com/doctest/doctest.git
+      GIT_TAG v2.4.12
+    )
+    FetchContent_MakeAvailable(doctest)
+    include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+  else()
+    find_package(doctest CONFIG REQUIRED)
+    # Many doctest packages also install the helper cmake file; try to locate it.
+    # If your doctest package already provides doctest_discover_tests, you can remove this.
+    include(doctest)
+  endif()
 
-  # Test executable
   add_executable(kedm-test
     test/main.cpp
     test/ccm_test.cpp

--- a/spack_repo/kedm/packages/kedm/package.py
+++ b/spack_repo/kedm/packages/kedm/package.py
@@ -1,0 +1,134 @@
+# Copyright Spack Project Developers.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import glob
+import os
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+
+class Kedm(CMakePackage, CudaPackage):
+    homepage = "https://github.com/freifrauvonbleifrei/kEDM"
+    git = "https://github.com/freifrauvonbleifrei/kEDM.git"
+
+    version("master", branch="master")
+
+    variant("cpu", default=True, description="Enable CPU (OpenMP) backend")
+    variant("cuda", default=False, description="Enable GPU (CUDA) backend")
+    variant("mpi", default=False, description="Enable MPI support")
+    variant("python", default=True, description="Build Python bindings")
+    variant("executables", default=True, description="Build executables")
+    variant("tests", default=False, description="Build unit tests")
+    variant("likwid", default=False, description="Enable LIKWID performance counters")
+    variant("scratch_memory", default=True, description="Use Kokkos scratch memory")
+    variant("simd_primitives", default=True, description="Use Kokkos SIMD primitives")
+
+    depends_on("cmake@3.22:", type="build")
+
+    # Core deps (external mode expects these discoverable by CMake)
+    depends_on("kokkos +openmp", when="+cpu")
+    depends_on("kokkos +cuda", when="+cuda")
+
+    depends_on("boost")  # provides Boost headers used by Boost.Math
+
+    # not currently in spack, but could be added
+    # depends_on("argh")
+    # depends_on("pcg-cpp")
+
+    # BLAS/LAPACK vs CUDA BLAS
+    depends_on("lapack", when="~cuda")
+    depends_on("cuda", when="+cuda")
+
+    # MPI
+    depends_on("mpi", when="+mpi")
+
+    # Executables: HighFive/HDF5
+    depends_on("highfive", when="+executables")
+    depends_on("hdf5", when="+executables")
+
+    # Optional LIKWID
+    depends_on("likwid", when="+likwid")
+
+    # Python bindings (use C++ pybind11 package, not only the Python module)
+    extends("python", when="+python")
+    depends_on("python@3.8:", when="+python")
+    depends_on("pybind11", when="+python")
+
+    # Tests
+    depends_on("doctest", when="+tests")
+
+    def cmake_args(self):
+        args = []
+
+        # Tell upstream to use find_package/find_path instead of FetchContent
+        args.append(self.define("KEDM_USE_EXTERNAL_DEPS", True))
+
+        args += [
+            self.define("KEDM_ENABLE_CPU", "+cpu" in self.spec),
+            self.define("KEDM_ENABLE_GPU", "+cuda" in self.spec),
+            self.define("KEDM_ENABLE_MPI", "+mpi" in self.spec),
+            self.define("KEDM_ENABLE_PYTHON", "+python" in self.spec),
+            self.define("KEDM_ENABLE_EXECUTABLES", "+executables" in self.spec),
+            self.define("KEDM_ENABLE_TESTS", "+tests" in self.spec),
+            self.define("KEDM_ENABLE_LIKWID", "+likwid" in self.spec),
+            self.define("KEDM_ENABLE_SCRATCH_MEMORY", "+scratch_memory" in self.spec),
+            self.define("KEDM_ENABLE_SIMD_PRIMITIVES", "+simd_primitives" in self.spec),
+        ]
+
+        # Note: cuda_arch forwarding into kokkos is handled by the kokkos dependency
+        # (Spack builds kokkos with the correct arch). No need to set Kokkos_ARCH_* here.
+
+        return args
+
+    def install(self, spec, prefix):
+        # Run upstream install (installs python module if enabled)
+        super().install(spec, prefix)
+
+        # Install library artifacts (upstream doesn't define install rules for kedm lib)
+        mkdirp(prefix.lib)
+
+        candidates = []
+        candidates += glob.glob(os.path.join(self.build_directory, "libkedm.*"))
+        candidates += glob.glob(os.path.join(self.build_directory, "kedm.*"))
+        for f in sorted(set(candidates)):
+            if os.path.isfile(f) and (
+                f.endswith(".a")
+                or f.endswith(".so")
+                or ".so." in f
+                or f.endswith(".dylib")
+            ):
+                install(f, prefix.lib)
+
+        # Install executables if built
+        if "+executables" in spec:
+            mkdirp(prefix.bin)
+            for exe in [
+                "edm-xmap",
+                "knn-bench",
+                "lookup-bench",
+                "smap-bench",
+                "partial-sort-bench",
+                "edm-xmap-mpi",
+            ]:
+                p = os.path.join(self.build_directory, exe)
+                if os.path.isfile(p) and os.access(p, os.X_OK):
+                    install(p, prefix.bin)
+
+        # Install headers
+        mkdirp(prefix.include)
+        incdir = os.path.join(prefix.include, "kedm")
+        mkdirp(incdir)
+        for pattern in ["*.hpp", "*.h", "*.cuh", "*.hh"]:
+            for hdr in glob.glob(os.path.join(self.stage.source_path, "src", pattern)):
+                install(hdr, incdir)
+
+        # License files (if present)
+        for fname in ["LICENSE", "LICENSE-THIRD-PARTY"]:
+            f = os.path.join(self.stage.source_path, fname)
+            if os.path.isfile(f):
+                install(f, prefix)
+
+    def test(self):
+        assert os.path.isdir(self.prefix.lib)

--- a/spack_repo/kedm/packages/kedm/package.py
+++ b/spack_repo/kedm/packages/kedm/package.py
@@ -10,8 +10,8 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 
 class Kedm(CMakePackage, CudaPackage):
-    homepage = "https://github.com/freifrauvonbleifrei/kEDM"
-    git = "https://github.com/freifrauvonbleifrei/kEDM.git"
+    homepage = "https://github.com/keichi/kEDM"
+    git = "https://github.com/keichi/kEDM.git"
 
     version("master", branch="master")
 
@@ -58,7 +58,7 @@ class Kedm(CMakePackage, CudaPackage):
     # Python bindings (use C++ pybind11 package, not only the Python module)
     extends("python", when="+python")
     depends_on("python@3.8:", when="+python")
-    depends_on("pybind11", when="+python")
+    depends_on("py-pybind11", when="+python")
 
     # Tests
     depends_on("doctest", when="+tests")

--- a/spack_repo/kedm/packages/kedm/package.py
+++ b/spack_repo/kedm/packages/kedm/package.py
@@ -25,11 +25,14 @@ class Kedm(CMakePackage, CudaPackage):
     variant("scratch_memory", default=True, description="Use Kokkos scratch memory")
     variant("simd_primitives", default=True, description="Use Kokkos SIMD primitives")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.22:", type="build")
 
     # Core deps (external mode expects these discoverable by CMake)
-    depends_on("kokkos +openmp", when="+cpu")
-    depends_on("kokkos +cuda", when="+cuda")
+    depends_on("kokkos@5.0.0: +openmp", when="+cpu")
+    depends_on("kokkos@5.0.0: +cuda", when="+cuda")
 
     depends_on("boost")  # provides Boost headers used by Boost.Math
 
@@ -46,7 +49,8 @@ class Kedm(CMakePackage, CudaPackage):
 
     # Executables: HighFive/HDF5
     depends_on("highfive", when="+executables")
-    depends_on("hdf5", when="+executables")
+    depends_on("hdf5 +cxx", when="+executables")
+    depends_on("hdf5 +cxx +mpi", when="+executables+mpi")
 
     # Optional LIKWID
     depends_on("likwid", when="+likwid")
@@ -76,9 +80,6 @@ class Kedm(CMakePackage, CudaPackage):
             self.define("KEDM_ENABLE_SCRATCH_MEMORY", "+scratch_memory" in self.spec),
             self.define("KEDM_ENABLE_SIMD_PRIMITIVES", "+simd_primitives" in self.spec),
         ]
-
-        # Note: cuda_arch forwarding into kokkos is handled by the kokkos dependency
-        # (Spack builds kokkos with the correct arch). No need to set Kokkos_ARCH_* here.
 
         return args
 

--- a/spack_repo/kedm/repo.yaml
+++ b/spack_repo/kedm/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: 'kedm'
+  api: v2.2


### PR DESCRIPTION
Hi @keichi !

Here's a draft for a spack package. I used it to install kEDM on my laptop, and am currently testing installation on miyabi (veeery slow but looking good so far). Here's how.

With spack and kEDM cloned in the work folder:

```console
export SPACK_PATH=$(pwd)/spack && export SPACK_USER_CONFIG_PATH="${SPACK_PATH}/user_config" && export SPACK_SYSTEM_CONFIG_PATH="${SPACK_PATH}/sys_config" && export SPACK_USER_CACHE_PATH="${SPACK_PATH}/user_cache" && . ${SPACK_PATH}/share/spack/setup-env.sh

spack compiler find
spack external find
```

I needed to manually add some installed dependencies to `${SPACK_PATH}/user_config/packages.yaml`:

```yaml
  cuda:
    externals:
    - spec: cuda@12.6
      prefix: /work/opt/local/aarch64/cores/cuda/12.6
    buildable: false
  openmpi:
    externals:
    - spec: openmpi@4.1.6 +cuda %nvhpc@25.9 ^cuda@12.6
      prefix: /work/opt/local/aarch64/apps/nvidia/25.9/openmpi-cuda/4.1.6-12.6
    buildable: false
```

Then, register the kedm repo with

```console
spack repo add kEDM/spack_repo/kedm/
```

and try the usual specification and install commands.
The latter has to be run from the kEDM folder and shows normal CMake output:

```console
spack spec kedm@master +cuda+executables+mpi+tests ^kokkos+cuda+wrapper cuda_arch=90 %nvhpc
spack dev-build kedm@master +cuda+executables+mpi+tests ^kokkos+cuda+wrapper cuda_arch=90 %nvhpc
```

Unfortunately, I could not test installation of the python bindings, because I consistently get

```console
$ spack spec kedm+python
==> Error: Spack concretizer internal error. Please submit a bug report and include the command, environment if applicable and the following error message.
    kedm+python is unsatisfiable
```

I'm not sure if it makes sense to submit an issue to spack about it (yet).

Hope this can be useful!
